### PR TITLE
Fix the crash on 404

### DIFF
--- a/serve_dist_bundle.js
+++ b/serve_dist_bundle.js
@@ -42,7 +42,7 @@ const prepareFile = async (url) => {
     const pathTraversal = !filePath.startsWith(STATIC_PATH);
     const exists = await fs.promises.access(filePath).then(...toBool);
     const found = !pathTraversal && exists;
-    const streamPath = found ? filePath : STATIC_PATH + "/404.html";
+    const streamPath = found ? filePath : STATIC_PATH + "/index.html";
     const ext = path.extname(streamPath).substring(1).toLowerCase();
     const stream = fs.createReadStream(streamPath);
     return { found, ext, stream };


### PR DESCRIPTION
Should just fall back to the index.html.

Maybe, at a later stage we can write a 404 page.